### PR TITLE
feat(free-study): add course type differentiation in payment form

### DIFF
--- a/app/components/ui/freeStudies/FreeStudyPaymentForm.tsx
+++ b/app/components/ui/freeStudies/FreeStudyPaymentForm.tsx
@@ -5,7 +5,7 @@ import { useStripe, useElements, CardElement } from '@stripe/react-stripe-js';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Controller, useForm } from 'react-hook-form';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { StripeCardElement } from '@stripe/stripe-js';
 import { toast } from 'sonner';
 import ErrorMsg from '../../common/ErrorMsg';
@@ -23,6 +23,10 @@ const FreeStudyPaymentForm = ({ freeStudy }: { freeStudy: FreeStudyCourse }) => 
   const elements = useElements();
   const [loading, setLoading] = useState(false);
   const queryClient = useQueryClient();
+  const path = usePathname();
+  const isFromFreeStudy = path.includes('free-study');
+
+  console.log('isFreeStudy', isFromFreeStudy);
 
   // const isFreeStudy = type === 'free-study';
   // const isSemester = type === 'semester';
@@ -40,6 +44,7 @@ const FreeStudyPaymentForm = ({ freeStudy }: { freeStudy: FreeStudyCourse }) => 
       const { data: CreateIntent } = await axiosInstance.post('/transaction', {
         item_id: freeStudy.id,
         type: 'course',
+        course_type: isFromFreeStudy ? 'free_study' : 'academic_study',
       });
 
       const { error } = await stripe.confirmCardPayment(CreateIntent?.data?.clientSecret, {

--- a/app/hooks/useCourseRequest.ts
+++ b/app/hooks/useCourseRequest.ts
@@ -1,10 +1,16 @@
 import { useMutation } from '@tanstack/react-query';
 import axiosInstance from '../lib/axios/instance';
+import { usePathname } from 'next/navigation';
 
 export const useCourseRequest = () => {
+  const path = usePathname();
+  const isFromFreeStudy = path.includes('free-study');
   return useMutation({
     mutationFn: async (course_id: string) => {
-      const { data } = await axiosInstance.post('/course-request', { course_id });
+      const { data } = await axiosInstance.post('/course-request', {
+        course_id,
+        course_type: isFromFreeStudy ? 'free_study' : 'academic_study',
+      });
       return data;
     },
   });


### PR DESCRIPTION
Add logic to determine if payment is for free study or academic study based on current path. This ensures correct course type is sent to the transaction API endpoint.